### PR TITLE
Support JSON cassettes by passing a filename ending in .json

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -124,6 +124,8 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, '-5') == '.json') {
             \VCR\VCR::configure()->setStorage('json');
+        } else {
+            \VCR\VCR::configure()->setStorage('yaml');
         }
 
         if (empty($cassetteName)) {


### PR DESCRIPTION
For example, for JSON do:

``` php
    /**
     * @vcr AccountInvoiceRequests.json
     */
    public function testInvoices()
    {
    }
```

And YAML:

``` php
    /**
     * @vcr AccountInvoiceRequests.yaml
     */
    public function testInvoices()
    {
    }
```
