### PR TITLE
Fixing pass-by-reference exception

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -119,7 +119,8 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         $doc_block  = $reflection->getDocComment();
 
         // Use regex to parse the doc_block for a specific annotation
-        $cassetteName = array_pop(self::parseDocBlock($doc_block, '@vcr'));
+        $parsed = $self::parseDocBlock($doc_block, '@vcr');
+        $cassetteName = array_pop($parsed);
 
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, '-5') == '.json') {


### PR DESCRIPTION
A recent PR is throwing a pass-by-reference exception because PHP in strict mode doesn't like it when non-variables are passed by reference.
