### PR TITLE
Fix typo when calling parseDocBlock method

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -119,7 +119,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         $doc_block  = $reflection->getDocComment();
 
         // Use regex to parse the doc_block for a specific annotation
-        $parsed = $self::parseDocBlock($doc_block, '@vcr');
+        $parsed = self::parseDocBlock($doc_block, '@vcr');
         $cassetteName = array_pop($parsed);
 
         // If the cassette name ends in .json, then use the JSON storage format


### PR DESCRIPTION
Hi! I'm using your library and after a composer update it seems that you missed a typo calling the parseDocBlock method.

This is the php error after the update:

```
PHP Notice:  Undefined variable: self in /home/vagrant/Core/externals/php-vcr/phpunit-testlistener-vcr/PHPUnit/Util/Log/VCR.php on line 122
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:46
PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php/PHPUnit/TextUI/Command.php:129
PHP   4. PHPUnit_TextUI_TestRunner->doRun() /usr/share/php/PHPUnit/TextUI/Command.php:176
PHP   5. PHPUnit_Framework_TestSuite->run() /home/vagrant/Core/externals/phpunit/phpunit/src/TextUI/TestRunner.php:423
PHP   6. PHPUnit_Framework_TestSuite->run() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   7. PHPUnit_Framework_TestSuite->run() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   8. PHPUnit_Framework_TestCase->run() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   9. PHPUnit_Framework_TestResult->run() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestCase.php:711
PHP  10. PHPUnit_Framework_TestResult->startTest() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestResult.php:581
PHP  11. PHPUnit_Util_Log_VCR->startTest() /home/vagrant/Core/externals/phpunit/phpunit/src/Framework/TestResult.php:365
```

pd: sorry for my english :)
