### PR TITLE
Add abiliy to enable matchers from within the docblock

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -129,12 +129,31 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
             \VCR\VCR::configure()->setStorage('yaml');
         }
 
+        $this->enableMatchers($doc_block);
+
         if (empty($cassetteName)) {
             return true;
         }
 
         \VCR\VCR::turnOn();
         \VCR\VCR::insertCassette($cassetteName);
+    }
+
+    private function enableMatchers($doc_block){
+        $parsed = self::parseDocBlock($doc_block, '@vcr_matchers');
+        $matchersString = isset($parsed) ? array_pop($parsed) : null;
+
+        // If we found matchers in the doc block
+        if(isset($matchersString)){
+            $explodedMatchers = explode(',', $matchersString);
+            // This is unfortunatly necessary as php will return an empty array if it doesn't find a delimiter
+            $matchersArray = $explodedMatchers ? $explodedMatchers : [$matchersString];
+            \VCR\VCR::configure()->enableRequestMatchers($matchersArray);
+        }
+        // If there are no matchers then set the matchers to the default list
+        else{
+            $matchersArray = ['method', 'url', 'query_string', 'host', 'headers', 'body', 'post_fields'];
+        }
     }
 
     private static function parseDocBlock($doc_block, $tag)


### PR DESCRIPTION
I want to be able to add custom matchers to tests where appropriate. This patch is the best I could come up with without modifying php-vcr in a non backwards compatible way. See the example below:

``` php
<?php

class ExampleTest extends TestCase
{
    public static function setUpBeforeClass(){
        // custom request matcher
        \VCR\VCR::configure()
            ->addRequestMatcher(
                'example_matcher',
                function (\VCR\Request $first, \VCR\Request $second) {
                    // matching code goes here
                }
            );
    }

    /**
     * @vcr xero_init_test
     * @vcr_matchers example_matcher
     */
    public function testXeroInit($accountId=1)
    {
        $result = $this->get("/xeroinit");
    }
}
```

I don't really like this part:

``` php
else{
    $matchersArray = ['method', 'url', 'query_string', 'host', 'headers', 'body', 'post_fields'];
}
```

However without it the custom matcher would be run for every test. I think ideally we would change php-vcr to create a list of default matchers which are separate from the list of matchers available to be enabled. Then when not providing a list of matchers it would only run the matchers in the default list and not everything.

Feedback?
