### PR TITLE
PHPUnit 5.1: Add addWarning() from interface

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -55,6 +55,19 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
+    
+    /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test    $test
+     * @param PHPUnit_Framework_Warning $e
+     * @param float                     $time
+     *
+     * @since Method available since Release 5.1.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
+    {
+    }
 
     /**
      * A failure occurred.


### PR DESCRIPTION
Without this, the unit tests throw a fatal error due to a missing method defined by the interface.