### PR TITLE
Add an option when VCR is enabled globally for all tests

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -43,6 +43,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
      */
     public function __construct(array $options = array())
     {
+        $this->options = $options;
     }
 
     /**
@@ -55,7 +56,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
-    
+
     /**
      * A warning occurred.
      *
@@ -144,7 +145,10 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
             return true;
         }
 
-        \VCR\VCR::turnOn();
+        if (!$this->options['enableGlobally']) {
+            \VCR\VCR::turnOn();
+        }
+
         \VCR\VCR::insertCassette($cassetteName);
     }
 
@@ -153,7 +157,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         $matches = array();
 
         if (empty($doc_block))
-        return $matches;
+            return $matches;
 
         $regex = "/{$tag} (.*)(\\r\\n|\\r|\\n)/U";
         preg_match_all($regex, $doc_block, $matches);
@@ -167,7 +171,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
 
         // Trim the results, array item by array item
         foreach ($matches as $ix => $match)
-        $matches[$ix] = trim( $match );
+            $matches[$ix] = trim( $match );
 
         return $matches;
     }
@@ -179,7 +183,9 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
      */
     public function endTest(PHPUnit_Framework_Test $test, $time)
     {
-        \VCR\VCR::turnOff();
+        if (!$this->options['enableGlobally']) {
+            \VCR\VCR::turnOff();
+        }
     }
 
     /**


### PR DESCRIPTION
I was facing an issue when some code is loaded in the `setUp` function in my tests and the VCR was activated too late.

The solution I found is to activate VCR in my phpunit bootstrap file and use this option to prevent turning on and off the VCR on each tests.