### PR TITLE
Ensure annotations work on tests that use dataProviders

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -122,7 +122,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
     public function startTest(PHPUnit_Framework_Test $test)
     {
         $class      = get_class($test);
-        $method     = $test->getName();
+        $method     = $test->getName(FALSE);
 
         if (!method_exists($class, $method)) {
             return;

--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -122,7 +122,7 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
     public function startTest(PHPUnit_Framework_Test $test)
     {
         $class      = get_class($test);
-        $method     = $test->getName(FALSE);
+        $method     = $test->getName(false);
 
         if (!method_exists($class, $method)) {
             return;

--- a/tests/PHPUnit/Util/Log/VCRTest.php
+++ b/tests/PHPUnit/Util/Log/VCRTest.php
@@ -23,4 +23,22 @@ class Util_Log_VCRTest extends PHPUnit_Framework_TestCase
         $result = file_get_contents('http://google.com');
         $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using annotations).');
     }
+
+    /**
+     * @vcr unittest_annotation_test
+     * @dataProvider aDataProvider
+     */
+    public function testInterceptsWithAnnotationsWhenUsingDataProvider($dummyValue)
+    {
+        // Content of tests/fixtures/unittest_annotation_test: "This is a annotation test dummy".
+        $result = file_get_contents('http://google.com');
+        $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using annotations with data provider).');
+    }
+
+    public function aDataProvider()
+    {
+        return array(
+            array(null)
+        );
+    }
 }

--- a/tests/PHPUnit/Util/Log/VCRTest.php
+++ b/tests/PHPUnit/Util/Log/VCRTest.php
@@ -38,7 +38,8 @@ class Util_Log_VCRTest extends PHPUnit_Framework_TestCase
     public function aDataProvider()
     {
         return array(
-            array(null)
+            array(1),
+            array(2)
         );
     }
 }


### PR DESCRIPTION
By default `$test->getName()` appends the name of the data set (e.g. "testInterceptsWithAnnotationsWhenUsingDataProvider with data set #0"). This means that the reflection to get the doc block doesn't work.