### PR TITLE
It's now possible to use the VCR annotation without any parameter

### DIFF
--- a/PHPUnit/Util/Log/VCR.php
+++ b/PHPUnit/Util/Log/VCR.php
@@ -112,7 +112,6 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
      */
     public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-
     }
 
     /**
@@ -136,6 +135,10 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
         // Use regex to parse the doc_block for a specific annotation
         $parsed = self::parseDocBlock($doc_block, '@vcr');
         $cassetteName = array_pop($parsed);
+
+        if ($cassetteName === null) {
+            $cassetteName = $class . '_' . $method;
+        }
 
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, '-5') == '.json') {
@@ -201,6 +204,5 @@ class PHPUnit_Util_Log_VCR implements PHPUnit_Framework_TestListener
      */
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-
     }
 }

--- a/tests/PHPUnit/Util/Log/VCRTest.php
+++ b/tests/PHPUnit/Util/Log/VCRTest.php
@@ -25,6 +25,15 @@ class Util_Log_VCRTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @vcr
+     */
+    public function testInterceptsWithAnnotationsUsesTestsNameAndClassAsCassetteName()
+    {
+        $result = file_get_contents('http://google.com');
+        $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using annotations).');
+    }
+
+    /**
      * @vcr unittest_annotation_test
      * @dataProvider aDataProvider
      */

--- a/tests/fixtures/Util_Log_VCRTest_testInterceptsWithAnnotationsUsesTestsNameAndClassAsCassetteName
+++ b/tests/fixtures/Util_Log_VCRTest_testInterceptsWithAnnotationsUsesTestsNameAndClassAsCassetteName
@@ -1,0 +1,19 @@
+
+-
+    request:
+        method: GET
+        url: 'http://google.com'
+        headers:
+            Host: google.com
+    response:
+        status:
+            http_version: '1.1'
+            code: '302'
+            message: Found
+        headers:
+            Cache-Control: private
+            Content-Type: 'text/html; charset=UTF-8'
+            Location: 'http://www.google.nl/?gfe_rd=cr&ei=J8MPWJbcNuLG8AfMqJbwAg'
+            Content-Length: '258'
+            Date: 'Tue, 25 Oct 2016 20:40:07 GMT'
+        body: "This is a annotation test dummy."


### PR DESCRIPTION
@adri what do you think about this?
- [ ] Check possible collision, use namespace maybe?
- [ ] The tag should be set to activate php-vcr, now any test is creating files (any test is being recorded)