### PR TITLE
Options via listener config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,7 +38,15 @@
     </filter>
 
     <listeners>
-        <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="src/VCRTestListener.php" />
+        <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="src/VCRTestListener.php">
+            <arguments>
+                <array>
+                    <element key="mode">
+                        <string>none</string>
+                    </element>
+                </array>
+            </arguments>
+        </listener>
     </listeners>
 
 </phpunit>

--- a/src/VCRTestListener.php
+++ b/src/VCRTestListener.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
+use VCR\Configuration;
 use VCR\VCR;
 
 /**
@@ -53,6 +54,7 @@ class VCRTestListener implements TestListener
      */
     public function __construct(array $options = array())
     {
+        $this->options = $options;
     }
 
     /**
@@ -146,6 +148,11 @@ class VCRTestListener implements TestListener
         $parsed = self::parseDocBlock($docBlock, '@vcr');
         $cassetteName = array_pop($parsed);
 
+        $configuration = VCR::configure();
+        foreach ($this->options as $option => $value) {
+            self::configure($configuration, $option, $value);
+        }
+
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, '-5') == '.json') {
             VCR::configure()->setStorage('json');
@@ -183,6 +190,29 @@ class VCRTestListener implements TestListener
         }
 
         return $matches;
+    }
+
+    private static function configure(Configuration $configuration, $option, $value)
+    {
+        switch ($option) {
+            case 'mode':
+                $configuration->setMode($value);
+                break;
+            case 'cassettePath':
+                $configuration->setCassettePath($value);
+                break;
+            case 'requestMatchers':
+                $configuration->enableRequestMatchers($value);
+                break;
+            case 'whiteList':
+                $configuration->setWhiteList($value);
+                break;
+            case 'blackList':
+                $configuration->setBlackList($value);
+                break;
+            default:
+                throw new \RuntimeException(sprintf("Unknown VCR configuration option \"%s\"", $option));
+        }
     }
 
     /**

--- a/tests/VCRTestListenerTest.php
+++ b/tests/VCRTestListenerTest.php
@@ -3,12 +3,19 @@
 namespace Tests\VCR\PHPUnit\TestListener;
 
 use PHPUnit\Framework\TestCase;
+use VCR\VCR;
 
 /**
  * Test integration of PHPVCR with PHPUnit using annotations.
  */
 class VCRTestListenerTest extends TestCase
 {
+    public function testTakesConfigurationFromListenerConfig()
+    {
+        // phpunit.xml.dist has already set the mode to "none", default is "new_episodes"
+        $this->assertEquals(VCR::MODE_NONE, VCR::configure()->getMode());
+    }
+
     /**
      * @vcr unittest_annotation_test
      */


### PR DESCRIPTION
This PR allows the user to set (most) PHP-VCR options via the PHPUnit listener configuration.

Example configuration:

```xml
    <listeners>
        <listener class="VCR\PHPUnit\TestListener\VCRTestListener">
            <arguments>
                <array>
                    <element key="mode">
                        <string>none</string>
                    </element>
                    <element key="cassettePath">
                        <string>tests/cassettes/</string>
                    </element>
                </array>
            </arguments>
        </listener>
    </listeners>
```