### PR TITLE
Make compatible with PHPUnit 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
     - php: 7.1
     - env: COMPOSER_FLAGS="--prefer-lowest"
       php: 7.1
+    - php: 7.2
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     },
     "require": {
-        "php-vcr/php-vcr": "^1.3"
+        "php-vcr/php-vcr": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2"
+        "phpunit/phpunit": "^7"
     }
 }

--- a/src/VCRTestListener.php
+++ b/src/VCRTestListener.php
@@ -62,7 +62,7 @@ class VCRTestListener implements TestListener
      * @param Exception $e
      * @param float     $time
      */
-    public function addError(Test $test, \Exception $e, $time)
+    public function addError(Test $test, \Throwable $t, float $time): void
     {
     }
 
@@ -75,7 +75,7 @@ class VCRTestListener implements TestListener
      *
      * @since Method available since Release 5.1.0
      */
-    public function addWarning(Test $test, Warning $e, $time)
+    public function addWarning(Test $test, Warning $e, float $time): void
     {
     }
 
@@ -86,7 +86,7 @@ class VCRTestListener implements TestListener
      * @param AssertionFailedError $e
      * @param float                $time
      */
-    public function addFailure(Test $test, AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
     {
     }
 
@@ -97,7 +97,7 @@ class VCRTestListener implements TestListener
      * @param \Exception $e
      * @param float      $time
      */
-    public function addIncompleteTest(Test $test, \Exception $e, $time)
+    public function addIncompleteTest(Test $test, \Throwable $e, float $time): void
     {
     }
 
@@ -108,7 +108,7 @@ class VCRTestListener implements TestListener
      * @param \Exception $e
      * @param float      $time
      */
-    public function addSkippedTest(Test $test, \Exception $e, $time)
+    public function addSkippedTest(Test $test, \Throwable $e, float $time): void
     {
     }
 
@@ -119,7 +119,7 @@ class VCRTestListener implements TestListener
      * @param \Exception $e
      * @param float      $time
      */
-    public function addRiskyTest(Test $test, \Exception $e, $time)
+    public function addRiskyTest(Test $test, \Throwable $e, float $time): void
     {
     }
 
@@ -130,7 +130,7 @@ class VCRTestListener implements TestListener
      *
      * @return bool|null
      */
-    public function startTest(Test $test)
+    public function startTest(Test $test): void
     {
         $class = get_class($test);
         $method = $test->getName(false);
@@ -152,7 +152,7 @@ class VCRTestListener implements TestListener
         }
 
         if (empty($cassetteName)) {
-            return true;
+            return;
         }
 
         VCR::turnOn();
@@ -191,7 +191,7 @@ class VCRTestListener implements TestListener
      * @param Test  $test
      * @param float $time
      */
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, float $time): void
     {
         VCR::turnOff();
     }
@@ -201,7 +201,7 @@ class VCRTestListener implements TestListener
      *
      * @param TestSuite $suite
      */
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
     }
 
@@ -210,7 +210,7 @@ class VCRTestListener implements TestListener
      *
      * @param TestSuite $suite
      */
-    public function endTestSuite(TestSuite $suite)
+    public function endTestSuite(TestSuite $suite): void
     {
     }
 }


### PR DESCRIPTION
PHPUnit 7 uses interfaces with "strict" typing and `Throwable` type-hint for exceptions.

These changes break backwards compatibility, so, I guess, they deserve new release.

Thank you in advance.