### PR TITLE
Move the Empty Check on $cassetteName Up

### DIFF
--- a/src/VCRTestListener.php
+++ b/src/VCRTestListener.php
@@ -45,13 +45,13 @@ final class VCRTestListener implements TestListener
         $parsed = self::parseDocBlock($docBlock, '@vcr');
         $cassetteName = array_pop($parsed);
 
+        if (empty($cassetteName)) {
+            return;
+        }
+
         // If the cassette name ends in .json, then use the JSON storage format
         if (substr($cassetteName, -5) === '.json') {
             VCR::configure()->setStorage('json');
-        }
-
-        if (empty($cassetteName)) {
-            return;
         }
 
         VCR::turnOn();

--- a/tests/VCRTestListenerTest.php
+++ b/tests/VCRTestListenerTest.php
@@ -40,6 +40,14 @@ final class VCRTestListenerTest extends TestCase
         $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using annotations with data provider).');
     }
 
+    /**
+     * @group https://github.com/php-vcr/phpunit-testlistener-vcr/issues/29
+     */
+    public function testNoVcrAnnotationRunsSuccessfulAndDoesNotProduceWarnings()
+    {
+        $this->assertTrue(true, 'just adding an assertion here');
+    }
+
     public function dummyDataProvider(): array
     {
         return [


### PR DESCRIPTION
So we don't do `substr` on a null and throw a `TypeError`

Closes #29 

I added a test case to reproduce this issue first if you'd like to see it fail.