### PR TITLE
Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - env: COMPOSER_FLAGS="--prefer-lowest"
       php: 7.1
     - php: 7.2
+    - php: 8.0
+      dist: bionic
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require": {
         "php-vcr/php-vcr": "^1.4",
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0|^8.0"
     }
 }


### PR DESCRIPTION
Basically the same as #37, but tests against PHP 8 on Bionic (where the package exists), and also allows newer `phpunit` (which is required for PHP 8). Thanks.